### PR TITLE
Switch to DATABASE_URL environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 TOKEN=
 
 # Vercel Postgres connection string
-POSTGRES_URL=
+DATABASE_URL=
 

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -5,7 +5,7 @@ Follow these steps to run the bot on Vercel.
 1. Push this repository to GitHub.
 2. In the Vercel dashboard choose **New Project** and import the repo.
 3. During setup add a Postgres database (Storage -> Add Database -> Postgres). Vercel
-   will create the database and populate the `POSTGRES_URL` environment variable.
+   will create the database and populate the `DATABASE_URL` environment variable.
 4. Add the environment variable `TOKEN` with the token provided by BotFather.
 5. Deploy the project. After the first deployment open the database console and
    execute the SQL schema from [docs/design.md](design.md).

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -6,7 +6,7 @@ import { connectToDb } from './database.js';
 export async function startApp() {
   try {
     loadEnv('../../.env');
-    validateEnv(['TOKEN', 'POSTGRES_URL']);
+    validateEnv(['TOKEN', 'DATABASE_URL']);
   } catch (error) {
     console.error('Error occurred while loading environment:', error);
     process.exit(1);

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -2,9 +2,9 @@ import { createPool } from '@vercel/postgres';
 import type { Database } from '../types/database.js';
 
 export async function connectToDb(): Promise<Database> {
-  const url = process.env.POSTGRES_URL;
+  const url = process.env.DATABASE_URL;
   if (!url) {
-    throw new Error('POSTGRES_URL is not set');
+    throw new Error('DATABASE_URL is not set');
   }
   return createPool({ connectionString: url });
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -3,7 +3,7 @@ export declare global {
   namespace NodeJS {
     interface ProcessEnv {
       TOKEN: string;
-      POSTGRES_URL: string;
+      DATABASE_URL: string;
     }
   }
 }

--- a/test/database.spec.ts
+++ b/test/database.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { connectToDb } from '../src/config/database.js';
 
 describe('connectToDb', () => {
-  it('resolves when POSTGRES_URL is provided', async () => {
-    process.env.POSTGRES_URL = 'postgres://user:pass@localhost/db';
+  it('resolves when DATABASE_URL is provided', async () => {
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost/db';
     await expect(connectToDb()).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- use `DATABASE_URL` instead of `POSTGRES_URL`
- update docs and `.env.example`
- adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883b951f650832abbf335256a1f28e0