### PR TITLE
Automate Vercel setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ TOKEN=
 # Vercel Postgres connection string
 DATABASE_URL=
 
+# Optional: base URL used to configure the Telegram webhook
+# (defaults to https://$VERCEL_URL if WEBHOOK_URL not set)
+WEBHOOK_URL=
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 
 # Sensitive data
 .env
+api/*.js

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ The repository follows a strict **test‑driven development** approach.  Every n
 2. `npm install`
 3. `npm test`
 
+The optional `WEBHOOK_URL` environment variable can override `VERCEL_URL` when
+setting up the Telegram webhook.
+
 See [docs/design.md](docs/design.md) for architectural details.
 
 ## Deploying to Vercel

--- a/README.md
+++ b/README.md
@@ -35,4 +35,6 @@ See [docs/design.md](docs/design.md) for architectural details.
 ## Deploying to Vercel
 
 Detailed deployment instructions are available in
-[docs/vercel-setup.md](docs/vercel-setup.md).
+[docs/vercel-setup.md](docs/vercel-setup.md). The build process runs
+`npm run postdeploy` which prepares the database schema and configures
+the Telegram webhook automatically.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ See [docs/design.md](docs/design.md) for architectural details.
 ## Deploying to Vercel
 
 Detailed deployment instructions are available in
-[docs/vercel-setup.md](docs/vercel-setup.md). The build process runs
-`npm run postdeploy` which prepares the database schema and configures
-the Telegram webhook automatically.
+[docs/vercel-setup.md](docs/vercel-setup.md). The `vercel.json` file
+sets the output directory to the repository root so Vercel deploys the
+compiled API functions. The build process runs `npm run postdeploy`
+which prepares the database schema and configures the Telegram webhook
+automatically.

--- a/api/bot.ts
+++ b/api/bot.ts
@@ -1,0 +1,25 @@
+import { webhookCallback } from 'grammy';
+import { connectToDb } from '../src/config/database.js';
+import { createBot } from '../src/config/bot.js';
+import { loadEnv } from '../src/helpers/load-env.js';
+import { validateEnv } from '../src/helpers/validate-env.js';
+
+let handler: ((req: any, res: any) => Promise<void> | void) | null = null;
+
+async function initHandler() {
+  if (!handler) {
+    if (!process.env.TOKEN || !process.env.DATABASE_URL) {
+      loadEnv('../.env');
+      validateEnv(['TOKEN', 'DATABASE_URL']);
+    }
+    const db = await connectToDb();
+    const bot = createBot(db);
+    handler = webhookCallback(bot, 'http');
+  }
+  return handler;
+}
+
+export default async function(req: any, res: any) {
+  const h = await initHandler();
+  return h(req, res);
+}

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -6,9 +6,12 @@ Follow these steps to run the bot on Vercel.
 2. In the Vercel dashboard choose **New Project** and import the repo.
 3. During setup add a Postgres database (Storage -> Add Database -> Postgres). Vercel
    will create the database and populate the `DATABASE_URL` environment variable.
-4. Add the environment variable `TOKEN` with the token provided by BotFather.
+4. Keep the default build command and output settings. The included `vercel.json`
+   sets the output directory to the repository root so the compiled `api/` functions
+   are deployed correctly.
+5. Add the environment variable `TOKEN` with the token provided by BotFather.
    The HTTP function defined in `api/bot.ts` will handle Telegram updates.
-5. Deploy the project. The build step runs `npm run postdeploy` which
+6. Deploy the project. The build step runs `npm run postdeploy` which
    automatically creates the database schema from `sql/schema.sql` and
    configures the Telegram webhook using `WEBHOOK_URL` or `VERCEL_URL`.
-6. Start chatting with your bot.
+7. Start chatting with your bot.

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -7,12 +7,7 @@ Follow these steps to run the bot on Vercel.
 3. During setup add a Postgres database (Storage -> Add Database -> Postgres). Vercel
    will create the database and populate the `DATABASE_URL` environment variable.
 4. Add the environment variable `TOKEN` with the token provided by BotFather.
-5. Deploy the project. After the first deployment open the database console and
-   execute the SQL schema from [docs/design.md](design.md).
-6. Set the Telegram webhook to point at your deployment:
-   `https://<project-name>.vercel.app/api/bot`.
-   Example using `curl`:
-   ```bash
-   curl "https://api.telegram.org/bot<token>/setWebhook?url=https://<project>.vercel.app/api/bot"
-   ```
-7. Start chatting with your bot.
+5. Deploy the project. The build step runs `npm run postdeploy` which
+   automatically creates the database schema from `sql/schema.sql` and
+   configures the Telegram webhook using `WEBHOOK_URL` or `VERCEL_URL`.
+6. Start chatting with your bot.

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -7,6 +7,7 @@ Follow these steps to run the bot on Vercel.
 3. During setup add a Postgres database (Storage -> Add Database -> Postgres). Vercel
    will create the database and populate the `DATABASE_URL` environment variable.
 4. Add the environment variable `TOKEN` with the token provided by BotFather.
+   The HTTP function defined in `api/bot.ts` will handle Telegram updates.
 5. Deploy the project. The build step runs `npm run postdeploy` which
    automatically creates the database schema from `sql/schema.sql` and
    configures the Telegram webhook using `WEBHOOK_URL` or `VERCEL_URL`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@biomejs/biome": "1.9.4",
         "@stylistic/eslint-plugin": "^2.3.0",
         "@tsconfig/recommended": "^1.0.7",
-        "@types/node": "^20.14.10",
+        "@types/node": "^24.1.0",
         "@types/pg": "^8.11.2",
         "@typescript-eslint/eslint-plugin": "^7.16.0",
         "@typescript-eslint/parser": "^7.16.0",
@@ -2700,12 +2700,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/pg": {
@@ -8120,9 +8120,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -8202,27 +8202,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
-    "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "build/index.js",
   "scripts": {
     "compile": "tsc",
-    "postcompile": "cp -r src/locales build",
-    "postdeploy": "node build/scripts/postdeploy.js",
+    "postcompile": "cp -r src/locales build && cp -r sql build",
+    "postdeploy": "node build/src/scripts/postdeploy.js",
     "build": "npm run compile && npm run postdeploy",
     "bg:start": "npm run prepare && pm2 start build/index.js --name telegram-bot",
     "bg:restart": "npm run prepare && pm2 restart telegram-bot",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@biomejs/biome": "1.9.4",
     "@stylistic/eslint-plugin": "^2.3.0",
     "@tsconfig/recommended": "^1.0.7",
-    "@types/node": "^20.14.10",
+    "@types/node": "^24.1.0",
     "@types/pg": "^8.11.2",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "compile": "tsc",
-    "postcompile": "cp -r src/locales build && cp -r sql build",
+    "postcompile": "cp -r src/locales build && cp -r sql build && mkdir -p api && cp build/api/* api/",
     "postdeploy": "node build/src/scripts/postdeploy.js",
     "build": "npm run compile && npm run postdeploy",
     "bg:start": "npm run prepare && pm2 start build/index.js --name telegram-bot",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "compile": "tsc",
     "postcompile": "cp -r src/locales build",
+    "postdeploy": "node build/scripts/postdeploy.js",
+    "build": "npm run compile && npm run postdeploy",
     "bg:start": "npm run prepare && pm2 start build/index.js --name telegram-bot",
     "bg:restart": "npm run prepare && pm2 restart telegram-bot",
     "bg:logs": "pm2 logs telegram-bot --lines 1000 -f",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "compile": "tsc",
-    "postcompile": "cp -r src/locales build && cp -r sql build && mkdir -p api && cp build/api/* api/",
+    "postcompile": "cp -r src/locales build/src && cp -r sql build && mkdir -p api && cp build/api/* api/",
     "postdeploy": "node build/src/scripts/postdeploy.js",
     "build": "npm run compile && npm run postdeploy",
     "bg:start": "npm run prepare && pm2 start build/index.js --name telegram-bot",
@@ -16,13 +16,7 @@
     "format": "npx biome format src/ --write",
     "test": "vitest run"
   },
-  "keywords": [
-    "telegram",
-    "bot",
-    "grammy",
-    "mongodb",
-    "typescript"
-  ],
+  "keywords": ["telegram", "bot", "grammy", "mongodb", "typescript"],
   "author": "ExposedCat",
   "license": "GPL-3.0-or-later",
   "dependencies": {

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS app_user (
+  user_id BIGINT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS chat (
+  chat_id BIGINT PRIMARY KEY,
+  title TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS word_base (
+  id SERIAL PRIMARY KEY,
+  owner_id BIGINT REFERENCES app_user(user_id),
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS word (
+  id SERIAL PRIMARY KEY,
+  base_id INTEGER REFERENCES word_base(id),
+  front TEXT NOT NULL,
+  back TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS exercise_state (
+  id SERIAL PRIMARY KEY,
+  base_id INTEGER REFERENCES word_base(id),
+  user_id BIGINT REFERENCES app_user(user_id),
+  position INTEGER DEFAULT 0,
+  multiplier REAL DEFAULT 1.5
+);
+
+CREATE TABLE IF NOT EXISTS score (
+  state_id INTEGER REFERENCES exercise_state(id),
+  word_id INTEGER REFERENCES word(id),
+  score REAL DEFAULT 1,
+  next_slot INTEGER DEFAULT 0,
+  PRIMARY KEY(state_id, word_id)
+);

--- a/src/config/bot.ts
+++ b/src/config/bot.ts
@@ -58,7 +58,7 @@ function setupControllers(bot: Bot) {
   bot.use(stopController);
 }
 
-export async function startBot(database: Database) {
+export function createBot(database: Database) {
   const localesPath = resolvePath(import.meta.url, '../locales');
   const i18n = initLocaleEngine(localesPath);
   const bot = new TelegramBot<CustomContext>(process.env.TOKEN);
@@ -67,6 +67,12 @@ export async function startBot(database: Database) {
   extendContext(bot, database);
   setupMiddlewares(bot, i18n);
   setupControllers(bot);
+
+  return bot;
+}
+
+export async function startBot(database: Database) {
+  const bot = createBot(database);
 
   return new Promise(resolve =>
     bot.start({

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -4,6 +4,8 @@ export declare global {
     interface ProcessEnv {
       TOKEN: string;
       DATABASE_URL: string;
+      VERCEL_URL?: string;
+      WEBHOOK_URL?: string;
     }
   }
 }

--- a/src/scripts/deploy.ts
+++ b/src/scripts/deploy.ts
@@ -23,4 +23,8 @@ export async function registerWebhook(token: string, baseUrl: string, fetchFn = 
     const text = await res.text();
     throw new Error(`Webhook setup failed: ${res.status} ${text}`);
   }
+  const data = (await res.json()) as { ok: boolean; description?: string };
+  if (!data.ok) {
+    throw new Error(`Webhook setup failed: ${data.description ?? 'unknown error'}`);
+  }
 }

--- a/src/scripts/deploy.ts
+++ b/src/scripts/deploy.ts
@@ -1,0 +1,26 @@
+import { readFile } from 'node:fs/promises';
+import type { Database } from '../types/database.js';
+
+export async function applySchema(db: Database) {
+  const file = new URL('../../sql/schema.sql', import.meta.url);
+  const sql = await readFile(file, 'utf8');
+  const statements = sql
+    .split(';')
+    .map(s => s.trim())
+    .filter(Boolean);
+  for (const stmt of statements) {
+    await db.query(stmt);
+  }
+}
+
+export async function registerWebhook(token: string, baseUrl: string, fetchFn = fetch) {
+  const url = `https://api.telegram.org/bot${token}/setWebhook?url=${baseUrl}/api/bot`;
+  const res = await fetchFn(url);
+  if (!('ok' in res)) {
+    throw new Error('Unexpected fetch implementation');
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Webhook setup failed: ${res.status} ${text}`);
+  }
+}

--- a/src/scripts/postdeploy.ts
+++ b/src/scripts/postdeploy.ts
@@ -1,0 +1,23 @@
+import { connectToDb } from '../config/database.js';
+import { applySchema, registerWebhook } from './deploy.js';
+import { fileURLToPath } from 'node:url';
+
+async function main() {
+  const db = await connectToDb();
+  await applySchema(db);
+  const baseUrl = process.env.WEBHOOK_URL || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '');
+  if (!process.env.TOKEN) {
+    throw new Error('TOKEN is not set');
+  }
+  if (!baseUrl) {
+    throw new Error('WEBHOOK_URL or VERCEL_URL must be set');
+  }
+  await registerWebhook(process.env.TOKEN, baseUrl);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/config/database.js', () => ({ connectToDb: vi.fn(async () => ({})) }));
+vi.mock('../src/config/bot.js', () => ({ createBot: vi.fn(() => ({})) }));
+vi.mock('grammy', () => ({ webhookCallback: vi.fn(() => vi.fn()) }));
+
+import handler from '../api/bot.js';
+import { connectToDb } from '../src/config/database.js';
+import { createBot } from '../src/config/bot.js';
+import { webhookCallback } from 'grammy';
+
+// biome-ignore lint/complexity/noUselessCatch:
+async function call() {
+  try {
+    await handler({} as any, {} as any);
+  } catch (e) {
+    throw e;
+  }
+}
+
+describe('api handler', () => {
+  it('initializes bot only once', async () => {
+    const cb = vi.fn();
+    (webhookCallback as unknown as vi.Mock).mockReturnValue(cb);
+    process.env.TOKEN = 't';
+    process.env.DATABASE_URL = 'postgres://x';
+
+    await call();
+    await call();
+
+    expect(createBot).toHaveBeenCalledTimes(1);
+    expect(connectToDb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 
 vi.mock('../src/config/database.js', () => ({ connectToDb: vi.fn(async () => ({})) }));
 vi.mock('../src/config/bot.js', () => ({ createBot: vi.fn(() => ({})) }));
@@ -21,7 +21,7 @@ async function call() {
 describe('api handler', () => {
   it('initializes bot only once', async () => {
     const cb = vi.fn();
-    (webhookCallback as unknown as vi.Mock).mockReturnValue(cb);
+    (webhookCallback as unknown as Mock).mockReturnValue(cb);
     process.env.TOKEN = 't';
     process.env.DATABASE_URL = 'postgres://x';
 

--- a/test/deploy.spec.ts
+++ b/test/deploy.spec.ts
@@ -14,10 +14,19 @@ describe('applySchema', () => {
 
 describe('registerWebhook', () => {
   it('calls Telegram API with proper URL', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
     await registerWebhook('abc', 'https://example.com', fetchMock);
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.telegram.org/botabc/setWebhook?url=https://example.com/api/bot'
+    );
+  });
+
+  it('throws when Telegram returns ok=false', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ ok: false, description: 'bad' }) });
+    await expect(registerWebhook('abc', 'https://example.com', fetchMock)).rejects.toThrow(
+      'Webhook setup failed: bad'
     );
   });
 });

--- a/test/deploy.spec.ts
+++ b/test/deploy.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applySchema, registerWebhook } from '../src/scripts/deploy.js';
+
+const schemaStatements = 6; // We'll check dynamic count but for test we compute
+
+describe('applySchema', () => {
+  it('runs each statement from schema file', async () => {
+    const executed: string[] = [];
+    const db = { query: async (sql: string) => { executed.push(sql); } } as any;
+    await applySchema(db);
+    expect(executed.length).toBeGreaterThan(0);
+  });
+});
+
+describe('registerWebhook', () => {
+  it('calls Telegram API with proper URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    await registerWebhook('abc', 'https://example.com', fetchMock);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.telegram.org/botabc/setWebhook?url=https://example.com/api/bot'
+    );
+  });
+});

--- a/test/postcompile.spec.ts
+++ b/test/postcompile.spec.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+
+describe('postcompile script', () => {
+  it('copies locales to build/src', () => {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as { scripts: Record<string, string> };
+    expect(pkg.scripts.postcompile).toMatch(/src\/locales\s+build\/src/);
+  });
+});

--- a/test/vercel-config.spec.ts
+++ b/test/vercel-config.spec.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+
+describe('vercel.json', () => {
+  it('uses root as output directory', () => {
+    const cfg = JSON.parse(readFileSync('vercel.json', 'utf8')) as { outputDirectory?: string };
+    expect(cfg.outputDirectory).toBe('.');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "outputDirectory": "."
+}


### PR DESCRIPTION
## Summary
- automate DB and webhook setup on Vercel builds
- document new automatic setup in docs and README
- expose WEBHOOK_URL variable
- add schema file and deployment tests

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6883bbaa2f54832ab9582cd4ad614c6e