### PR TITLE
Add PDF chat logs for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,3 +18,7 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run test:e2e -- --shard=${{ matrix.shard }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: e2e-reports
+          path: test/e2e/reports/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ build
 
 # Built dependencies
 node_modules
+# Test outputs
+coverage
 
 # Sensitive data
 .env
 api/*.js
+test/e2e/reports

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -12,3 +12,6 @@ As a new user I want to create my own word base so that I can train translations
 6. I answer a few correctly and a few incorrectly and receive feedback each time.
 
 This scenario is covered by end‑to‑end tests under `test/e2e`.
+Each run captures the full chat transcript and stores it as a PDF in
+`test/e2e/reports`. The CI workflow uploads these PDFs as artifacts so they can be
+downloaded from GitHub Actions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.34.3",
         "eslint-plugin-sonarjs": "^1.0.3",
+        "pdfkit": "^0.17.1",
         "prettier": "^3.3.2",
         "prettier-eslint": "^16.3.0",
         "telegram-test-api": "^4.2.1",
@@ -2845,6 +2846,16 @@
         "eslint": ">=8.40.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tsconfig/recommended": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.7.tgz",
@@ -3771,6 +3782,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.23.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
@@ -3982,6 +4003,16 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4095,6 +4126,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4320,6 +4358,13 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5728,6 +5773,24 @@
         }
       }
     },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -6857,6 +6920,13 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6974,6 +7044,27 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/locate-path": {
@@ -7727,6 +7818,13 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7838,6 +7936,20 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -7899,6 +8011,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==",
+      "dev": true
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -8411,6 +8529,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -9210,6 +9335,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9346,9 +9478,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
       "license": "0BSD"
     },
@@ -9504,6 +9636,28 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,7 @@
     "test:unit": "vitest run --coverage --exclude \"test/e2e/**\"",
     "test:e2e": "vitest run test/e2e --coverage"
   },
-  "keywords": [
-    "telegram",
-    "bot",
-    "grammy",
-    "mongodb",
-    "typescript"
-  ],
+  "keywords": ["telegram", "bot", "grammy", "mongodb", "typescript"],
   "author": "ExposedCat",
   "license": "GPL-3.0-or-later",
   "dependencies": {
@@ -53,6 +47,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-sonarjs": "^1.0.3",
+    "pdfkit": "^0.17.1",
     "prettier": "^3.3.2",
     "prettier-eslint": "^16.3.0",
     "telegram-test-api": "^4.2.1",

--- a/test/e2e/user-story.e2e.spec.ts
+++ b/test/e2e/user-story.e2e.spec.ts
@@ -4,6 +4,7 @@ import { createBot } from '../../src/config/bot.js';
 import type { CustomContext } from '../../src/types/context.js';
 import type { Database } from '../../src/types/database.js';
 import { Bot } from 'grammy';
+import { ChatLogger, generatePdf } from '../helpers/chat-logger.js';
 
 function createMemoryDb(): Database {
   let baseId = 1;
@@ -50,6 +51,7 @@ function createMemoryDb(): Database {
 describe('basic user story e2e', () => {
   let server: TelegramServer;
   let bot: Bot<CustomContext>;
+  const logger = new ChatLogger();
 
   beforeEach(async () => {
     server = new TelegramServer({ port: 9998 });
@@ -69,33 +71,60 @@ describe('basic user story e2e', () => {
     const client = server.getClient('test-token');
 
     await client.sendCommand(client.makeCommand('/menu'));
+    logger.logUser('/menu');
     await server.waitBotMessage();
     let updates = await client.getUpdates();
-    const menuMsgId = updates.result[0].message.message_id;
+    const menuUpdate = updates.result[0].message;
+    logger.logBot(
+      menuUpdate.text!,
+      menuUpdate.reply_markup?.inline_keyboard?.flat().map(b => b.text),
+    );
+    const menuMsgId = menuUpdate.message_id;
 
     await client.sendCallback(client.makeCallbackQuery('create_base', { message: { message_id: menuMsgId } }));
+    logger.logUser('tap Create base');
     await server.waitBotMessage();
     await client.getUpdates();
     await client.sendMessage(client.makeMessage('My base'));
+    logger.logUser('My base');
     await server.waitBotMessage();
     updates = await client.getUpdates();
-    const newMenuMsgId = updates.result.at(-1)!.message.message_id;
+    const createUpdate = updates.result.at(-1)!.message;
+    logger.logBot(
+      createUpdate.text!,
+      createUpdate.reply_markup?.inline_keyboard?.flat().map(b => b.text),
+    );
+    const newMenuMsgId = createUpdate.message_id;
 
     await client.sendCallback(client.makeCallbackQuery('open_base:1', { message: { message_id: newMenuMsgId } }));
+    logger.logUser('open base');
     await server.waitBotMessage();
     updates = await client.getUpdates();
-    const baseMsgId = updates.result.at(-1)!.message.message_id;
+    const baseUpdate = updates.result.at(-1)!.message;
+    logger.logBot(
+      baseUpdate.text!,
+      baseUpdate.reply_markup?.inline_keyboard?.flat().map(b => b.text),
+    );
+    const baseMsgId = baseUpdate.message_id;
 
     async function addWord(front: string, back: string) {
       await client.sendCallback(client.makeCallbackQuery(`add_word:1`, { message: { message_id: baseMsgId } }));
+      logger.logUser('add word');
       await server.waitBotMessage();
       await client.getUpdates();
       await client.sendMessage(client.makeMessage(front));
+      logger.logUser(front);
       await server.waitBotMessage();
       await client.getUpdates();
       await client.sendMessage(client.makeMessage(back));
+      logger.logUser(back);
       await server.waitBotMessage();
-      await client.getUpdates();
+      const res = await client.getUpdates();
+      const msg = res.result.at(-1)!.message;
+      logger.logBot(
+        msg.text!,
+        msg.reply_markup?.inline_keyboard?.flat().map(b => b.text),
+      );
     }
 
     await addWord('hello', 'hola');
@@ -103,12 +132,19 @@ describe('basic user story e2e', () => {
 
     async function exercise(answer: string) {
       await client.sendCallback(client.makeCallbackQuery(`exercise:1`, { message: { message_id: baseMsgId } }));
+      logger.logUser('start exercise');
       await server.waitBotMessage();
       await client.getUpdates();
       await client.sendMessage(client.makeMessage(answer));
+      logger.logUser(answer);
       await server.waitBotMessage();
       const res = await client.getUpdates();
-      return res.result.at(-1)!.message.text;
+      const msg = res.result.at(-1)!.message;
+      logger.logBot(
+        msg.text!,
+        msg.reply_markup?.inline_keyboard?.flat().map(b => b.text),
+      );
+      return msg.text!;
     }
 
     const okText = await exercise('hola');
@@ -116,5 +152,7 @@ describe('basic user story e2e', () => {
 
     expect(okText).toBe('Correct');
     expect(failText.startsWith('Incorrect')).toBe(true);
+
+    generatePdf(logger.getEvents(), 'test/e2e/reports/user-story.pdf');
   });
 });

--- a/test/helpers/chat-logger.ts
+++ b/test/helpers/chat-logger.ts
@@ -1,0 +1,50 @@
+export type Event = { role: 'bot'; text: string; buttons?: string[] } | { role: 'user'; text: string };
+
+export class ChatLogger {
+  private events: Event[] = [];
+
+  logBot(text: string, buttons?: string[]) {
+    this.events.push({ role: 'bot', text, buttons });
+  }
+
+  logUser(text: string) {
+    this.events.push({ role: 'user', text });
+  }
+
+  getEvents() {
+    return this.events;
+  }
+}
+
+import fs from 'fs';
+import PDFDocument from 'pdfkit';
+
+export function generatePdf(events: Event[], file: string) {
+  const doc = new PDFDocument({ margin: 40 });
+  doc.pipe(fs.createWriteStream(file));
+  let y = 40;
+  const left = 50;
+  const right = 300;
+  const lineHeight = 20;
+
+  for (const ev of events) {
+    const x = ev.role === 'bot' ? left : right;
+    doc.text(ev.text, x, y, {
+      width: 200,
+    });
+    y += lineHeight;
+    if (ev.role === 'bot' && ev.buttons) {
+      for (const b of ev.buttons) {
+        doc.text(`[${b}]`, x + 10, y, { width: 180 });
+        y += lineHeight;
+      }
+    }
+    y += 5;
+    if (y > doc.page.height - 40) {
+      doc.addPage();
+      y = 40;
+    }
+  }
+
+  doc.end();
+}


### PR DESCRIPTION
## Summary
- record bot and user messages in e2e tests
- generate simple Telegram‑style PDFs
- upload PDFs as artifacts in the e2e workflow
- document new reports in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b1aebabc0832a8ec9d51a88a39e7c