### PR TITLE
Fix failing tests and update keyboard test

### DIFF
--- a/src/controllers/menu.ts
+++ b/src/controllers/menu.ts
@@ -3,18 +3,18 @@ import type { Conversation } from '@grammyjs/conversations';
 import { Composer } from 'grammy';
 import { waitText } from '../helpers/wait-text.js';
 import { checkTranslation } from '../services/exercise.js';
+import { getCurrentVocabularyId, setCurrentVocabulary } from '../services/user.js';
 import {
   createVocabulary,
   deleteVocabulary,
-  renameVocabulary,
-  listVocabularies,
   getVocabulary,
+  listVocabularies,
+  renameVocabulary,
 } from '../services/vocabulary.js';
 import { addWord, getRandomWord } from '../services/word.js';
 import type { CustomContext } from '../types/context.js';
-import { kbMenu, kbVocabularies, kbVocabulary, kbExercises } from '../ui/keyboards.js';
+import { kbExercises, kbMenu, kbVocabularies, kbVocabulary } from '../ui/keyboards.js';
 import { CONVERSATION_NAMES } from './CONVERSATION_NAMES.js';
-import { setCurrentVocabulary, getCurrentVocabularyId } from '../services/user.js';
 
 export const menuController = new Composer<CustomContext>();
 

--- a/test/e2e/help.e2e.spec.ts
+++ b/test/e2e/help.e2e.spec.ts
@@ -20,7 +20,7 @@ function createBot(apiRoot: string, logger: ChatLogger) {
       ctx.reply(key === 'help' ? 'Use /menu to manage vocabularies and start exercises' : key);
     ctx.db = { query: async () => ({ rows: [] }) } as any;
     ctx.dbEntities = {
-      user: { user_id: ctx.from.id, name: 'Test' },
+      user: { user_id: ctx.from.id, name: 'Test', current_vocab_id: null },
       chat: null,
     };
     await next();

--- a/test/keyboards.spec.ts
+++ b/test/keyboards.spec.ts
@@ -1,21 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { kbBase } from '../src/ui/keyboards.js';
+import { kbVocabulary } from '../src/ui/keyboards.js';
+import type { InlineKeyboardButton } from '@grammyjs/types';
 
-describe('kbBase', () => {
+describe('kbVocabulary', () => {
   it('uses callback data with id', () => {
-    const kb = kbBase(42);
-    const rows = kb.inline_keyboard.map(row =>
+    const kb = kbVocabulary(42);
+    const rows = kb.inline_keyboard.map((row: InlineKeyboardButton[]) =>
       row.map(b => ({
         text: b.text,
-        data: (b as any).callback_data,
+        data: (b as InlineKeyboardButton.CallbackButton).callback_data,
       })),
     );
     expect(rows).toEqual([
       [{ text: 'Add word', data: 'add_word:42' }],
-      [{ text: 'Rename base', data: 'rename_base:42' }],
-      [{ text: 'Delete base', data: 'delete_base:42' }],
-      [{ text: 'Exercise', data: 'exercise:42' }],
-      [{ text: 'Back', data: 'back_to_bases' }],
+      [{ text: 'Rename', data: 'rename_vocab:42' }],
+      [{ text: 'Delete', data: 'delete_vocab:42' }],
+      [{ text: 'Select', data: 'select_vocab:42' }],
+      [{ text: 'Back', data: 'back_to_vocabularies' }],
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- update help.e2e context to include `current_vocab_id`
- migrate keyboard unit test to new `kbVocabulary` API
- run Biome formatting which updated menu controller

## Testing
- `npm test`
- `npm run test:unit`
- `npm run lint`
- `npm run test:e2e`
- `npm run mutation`


------
https://chatgpt.com/codex/tasks/task_e_688cfe8a4dd0832a8d844cd3afe7a09a