### PR TITLE
Fix missing column migration

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -4,6 +4,9 @@ CREATE TABLE IF NOT EXISTS app_user (
   current_vocab_id INTEGER REFERENCES vocabulary(id)
 );
 
+ALTER TABLE app_user
+  ADD COLUMN IF NOT EXISTS current_vocab_id INTEGER REFERENCES vocabulary(id);
+
 CREATE TABLE IF NOT EXISTS chat (
   chat_id BIGINT PRIMARY KEY,
   title TEXT NOT NULL

--- a/test/deploy.spec.ts
+++ b/test/deploy.spec.ts
@@ -14,6 +14,16 @@ describe('applySchema', () => {
     await applySchema(db);
     expect(executed.length).toBe(schemaStatements);
   });
+
+  it('adds current_vocab_id column if missing', async () => {
+    const executed: string[] = [];
+    const db = { query: async (sql: string) => { executed.push(sql); } } as any;
+    await applySchema(db);
+    const normalized = executed.map(s => s.replace(/\s+/g, ' ').trim());
+    expect(normalized).toContain(
+      'ALTER TABLE app_user ADD COLUMN IF NOT EXISTS current_vocab_id INTEGER REFERENCES vocabulary(id)',
+    );
+  });
 });
 
 describe('registerWebhook', () => {


### PR DESCRIPTION
## Summary
- ensure `current_vocab_id` column exists by adding an ALTER TABLE statement
- test that `applySchema` executes the new migration

## Testing
- `npm test`
- `npm run test:unit`
- `npm run test:e2e`
- `npm run lint`
- `npm run mutation`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688d044c372c832a8401e3715d65ca92