### PR TITLE
fix: include graphile-migrate config and test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,4 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm test
+      - run: npm run test:migrations

--- a/.gmrc
+++ b/.gmrc
@@ -1,0 +1,139 @@
+/*
+ * Graphile Migrate configuration.
+ *
+ * If you decide to commit this file (recommended) please ensure that it does
+ * not contain any secrets (passwords, etc) - we recommend you manage these
+ * with environmental variables instead.
+ *
+ * This file is in JSON5 format, in VSCode you can use "JSON with comments" as
+ * the file format.
+ */
+{
+  /*
+   * connectionString: this tells Graphile Migrate where to find the database
+   * to run the migrations against.
+   *
+   * RECOMMENDATION: use `DATABASE_URL` envvar instead.
+   */
+  // "connectionString": "postgres://appuser:apppassword@host:5432/appdb",
+
+  /*
+   * shadowConnectionString: like connectionString, but this is used for the
+   * shadow database (which will be reset frequently).
+   *
+   * RECOMMENDATION: use `SHADOW_DATABASE_URL` envvar instead.
+   */
+  // "shadowConnectionString": "postgres://appuser:apppassword@host:5432/appdb_shadow",
+
+  /*
+   * rootConnectionString: like connectionString, but this is used for
+   * dropping/creating the database in `graphile-migrate reset`. This isn't
+   * necessary, shouldn't be used in production, but helps during development.
+   *
+   * RECOMMENDATION: use `ROOT_DATABASE_URL` envvar instead.
+   */
+  // "rootConnectionString": "postgres://adminuser:adminpassword@host:5432/postgres",
+
+  /*
+   * pgSettings: key-value settings to be automatically loaded into PostgreSQL
+   * before running migrations, using an equivalent of `SET LOCAL <key> TO
+   * <value>`
+   */
+  "pgSettings": {
+    // "search_path": "app_public,app_private,app_hidden,public",
+  },
+
+  /*
+   * placeholders: substituted in SQL files when compiled/executed. Placeholder
+   * keys should be prefixed with a colon and in all caps, like
+   * `:COLON_PREFIXED_ALL_CAPS`. Placeholder values should be strings. They
+   * will be replaced verbatim with NO ESCAPING AT ALL (this differs from how
+   * psql handles placeholders) so should only be used with "safe" values. This
+   * is useful for committing migrations where certain parameters can change
+   * between environments (development, staging, production) but you wish to
+   * use the same signed migration files for all.
+   *
+   * The special value "!ENV" can be used to indicate an environmental variable
+   * of the same name should be used.
+   *
+   * Graphile Migrate automatically sets the `:DATABASE_NAME` and
+   * `:DATABASE_OWNER` placeholders, and you should not attempt to override
+   * these.
+   */
+  "placeholders": {
+    // ":DATABASE_VISITOR": "!ENV", // Uses process.env.DATABASE_VISITOR
+  },
+
+  /*
+   * Actions allow you to run scripts or commands at certain points in the
+   * migration lifecycle. SQL files are ran against the database directly.
+   * "command" actions are ran with the following environmental variables set:
+   *
+   * - GM_DBURL: the PostgreSQL URL of the database being migrated
+   * - GM_DBNAME: the name of the database from GM_DBURL
+   * - GM_DBUSER: the user from GM_DBURL
+   * - GM_SHADOW: set to 1 if the shadow database is being migrated, left unset
+   *   otherwise
+   *
+   * If "shadow" is unspecified, the actions will run on events to both shadow
+   * and normal databases. If "shadow" is true the action will only run on
+   * actions to the shadow DB, and if false only on actions to the main DB.
+   */
+
+  /*
+   * afterReset: actions executed after a `graphile-migrate reset` command.
+   */
+  "afterReset": [
+    // "afterReset.sql",
+    // { "_": "command", "command": "graphile-worker --schema-only" },
+  ],
+ 
+  /*
+   * afterAllMigrations: actions executed once all migrations are complete.
+   */
+  "afterAllMigrations": [
+    // {
+    //   "_": "command",
+    //   "shadow": true,
+    //   "command": "if [ \"$IN_TESTS\" != \"1\" ]; then ./scripts/dump-db; fi",
+    // },
+  ],
+
+  /*
+   * afterCurrent: actions executed once the current migration has been
+   * evaluated (i.e. in watch mode).
+   */
+  "afterCurrent": [
+    // {
+    //   "_": "command",
+    //   "shadow": true,
+    //   "command": "if [ \"$IN_TESTS\" = \"1\" ]; then ./scripts/test-seed; fi",
+    // },
+  ],
+
+  /*
+   * blankMigrationContent: content to be written to the current migration
+   * after commit. NOTE: this should only contain comments.
+   */
+  // "blankMigrationContent": "-- Write your migration here\n",
+
+  /****************************************************************************\
+  ***                                                                        ***
+  ***         You probably don't want to edit anything below here.           ***
+  ***                                                                        ***
+  \****************************************************************************/
+
+  /*
+   * manageGraphileMigrateSchema: if you set this false, you must be sure to
+   * keep the graphile_migrate schema up to date yourself. We recommend you
+   * leave it at its default.
+   */
+  // "manageGraphileMigrateSchema": true,
+
+  /*
+   * migrationsFolder: path to the folder in which to store your migrations.
+   */
+  // migrationsFolder: "./migrations",
+
+  "//generatedWith": "1.4.1"
+}

--- a/migrations/committed/000001.sql
+++ b/migrations/committed/000001.sql
@@ -1,3 +1,6 @@
+--! Previous: -
+--! Hash: sha1:e1ddf290fd7294500d216d56cee6c0ce83270212
+
 CREATE TABLE app_user (
   user_id BIGINT PRIMARY KEY,
   name TEXT NOT NULL

--- a/test/deploy.spec.ts
+++ b/test/deploy.spec.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
+import { existsSync } from 'node:fs';
+
+describe('project setup', () => {
+  it('includes graphile-migrate config', () => {
+    expect(existsSync('.gmrc')).toBe(true);
+  });
+});
 
 describe('runMigrations', () => {
   it('executes graphile-migrate CLI', async () => {

--- a/test/migrations.spec.ts
+++ b/test/migrations.spec.ts
@@ -2,8 +2,18 @@ import { describe, it } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { newDb } from 'pg-mem';
+import { parseMigrationText } from 'graphile-migrate/dist/migration.js';
 
 describe('migrations', () => {
+  it('have valid Graphile headers', () => {
+    const dir = join(process.cwd(), 'migrations', 'committed');
+    const files = readdirSync(dir).filter(f => f.endsWith('.sql')).sort();
+    for (const file of files) {
+      const sql = readFileSync(join(dir, file), 'utf8');
+      parseMigrationText(join(dir, file), sql, true);
+    }
+  });
+
   it('apply without errors', async () => {
     const db = newDb();
     const pg = db.adapters.createPg();
@@ -13,7 +23,8 @@ describe('migrations', () => {
     const files = readdirSync(dir).filter(f => f.endsWith('.sql')).sort();
     for (const file of files) {
       const sql = readFileSync(join(dir, file), 'utf8');
-      await client.query(sql);
+      const { body } = parseMigrationText(join(dir, file), sql, true);
+      await client.query(body);
     }
     await client.end();
   });


### PR DESCRIPTION
## Summary
- add Graphile Migrate `.gmrc` configuration file
- run migration tests in CI
- ensure `.gmrc` exists via unit test

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm test`
- `npm run test:e2e`
- `npm run test:migrations`
- `npm run mutation`


------
https://chatgpt.com/codex/tasks/task_e_688f93443628832a83d620ccbd5d4738